### PR TITLE
Change OSGeo URL to uk.osgeo.org

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -25,7 +25,7 @@
         <a href="https://www.turing.ac.uk/"><img src="/img/logos/logo_ati.png"
             alt="ATI" width="13%" hspace="5">
         </a>
-        <a href="https://osgeo.org/"><img src="/img/logos/OSGeoUK2.png"
+        <a href="https://uk.osgeo.org/"><img src="/img/logos/OSGeoUK2.png"
             alt="OSGeo" width="15%" hspace="5">
         </a>
         <a href="https://www.cartography.org.uk/"><img


### PR DESCRIPTION
Please can we tweak the URL to link to the OSGeo:UK website, rather than central OSGeo.org? Thanks, Nick.